### PR TITLE
fix old migration

### DIFF
--- a/db/migrate/20171104115558_create_blogposts.rb
+++ b/db/migrate/20171104115558_create_blogposts.rb
@@ -3,7 +3,7 @@ class CreateBlogposts < ActiveRecord::Migration[5.1]
     create_table :blogposts do |t|
       t.string :title
       t.text :description
-      t.string :display_name
+      t.string :author_name
       t.datetime :published_at
       t.string :slug
 


### PR DESCRIPTION
attention: this is bad practice!

I think originally when we had the merge conflict with the migrations we did a search and replace for  all instances of "author_name" and replaced them with "display_name". This is fine, except we also replaced "author_name" with "display_name" in the very first migration that created the blogpost table. That means that when the 4th or so migration ran that changed the author_name to display_name, it crashed, because it couldn't find author_name. 

In the future, we should be careful to never change old migrations because they all build upon each other and changing past ones can have unfortunate future results! its' ok now tho since we have no data. But once I've pushed everyone will have to do:

`bundle exec rake db:drop && bundle exec rake db:create && bundle exec rake db:migrate` 

to fix all the things.

🎉 